### PR TITLE
Add Google Sheets update support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,9 @@ dependencies {
     implementation("io.ktor:ktor-client-core-jvm:3.2.3")
     implementation("dev.inmo:krontab:2.7.2")
     implementation("org.jetbrains.kotlinx:kandy-lets-plot:0.8.0")
+    implementation("com.google.api-client:google-api-client:2.2.0")
+    implementation("com.google.auth:google-auth-library-oauth2-http:1.20.0")
+    implementation("com.google.apis:google-api-services-sheets:v4-rev20240423-2.0.0")
 }
 
 tasks.test {

--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -66,6 +66,14 @@ suspend fun sendAnswer(chatId: IdChatIdentifier) {
     val msg = getMessage()
     photos[0] = TelegramMediaPhoto(photos.first().file, msg)
     bot.sendMediaGroup(chatId, photos)
+    val spreadsheetId = System.getenv("SPREADSHEET_ID")
+    if (spreadsheetId != null) {
+        val sheet = System.getenv("SHEET_NAME") ?: "Sheet1"
+        val cell = System.getenv("CELL_ADDRESS") ?: "A1"
+        getRates()?.prices?.get("EUR")?.toString()?.let { priceValue ->
+            updateSheet(spreadsheetId, sheet, cell, priceValue)
+        }
+    }
     KSLog.info(msg)
 }
 

--- a/src/main/kotlin/Sheets.kt
+++ b/src/main/kotlin/Sheets.kt
@@ -1,0 +1,26 @@
+import com.google.api.client.http.javanet.NetHttpTransport
+import com.google.api.client.json.gson.GsonFactory
+import com.google.api.services.sheets.v4.Sheets
+import com.google.api.services.sheets.v4.model.ValueRange
+import com.google.auth.http.HttpCredentialsAdapter
+import com.google.auth.oauth2.ServiceAccountCredentials
+import java.io.ByteArrayInputStream
+
+suspend fun updateSheet(spreadsheetId: String, sheetName: String, cell: String, value: String) {
+    val credentialsJson = System.getenv("GOOGLE_CREDENTIALS") ?: return
+    val credentials = ServiceAccountCredentials.fromStream(ByteArrayInputStream(credentialsJson.toByteArray()))
+        .createScoped(listOf("https://www.googleapis.com/auth/spreadsheets"))
+    val service = Sheets.Builder(
+        NetHttpTransport(),
+        GsonFactory.getDefaultInstance(),
+        HttpCredentialsAdapter(credentials)
+    )
+        .setApplicationName("TonAlertBot")
+        .build()
+
+    val range = "$sheetName!$cell"
+    val body = ValueRange().setValues(listOf(listOf(value)))
+    service.spreadsheets().values().update(spreadsheetId, range, body)
+        .setValueInputOption("RAW")
+        .execute()
+}


### PR DESCRIPTION
## Summary
- integrate Google Sheets API dependencies
- add helper to update specified spreadsheet cell
- update bot to send latest TON price to a configured spreadsheet cell after messages

## Testing
- `./gradlew test` *(fails: Dependency com.github.centralhardware:ktgbotapi-commons:27.1.2-1 is only compatible with JVM runtime version 24 or newer)*

------
https://chatgpt.com/codex/tasks/task_e_689828bba3f083258b143622bd8bd5d8